### PR TITLE
If a monitor is not assigned a location, attempting to save the monitor ...

### DIFF
--- a/pkg/services/sqlstore/monitor.go
+++ b/pkg/services/sqlstore/monitor.go
@@ -380,6 +380,10 @@ func AddMonitor(cmd *m.AddMonitorCommand) error {
 				LocationId: l,
 			})
 		}
+		if len(monitor_locations) == 0 {
+			err = fmt.Errorf("No monitor locations chosen")
+			return err
+		}
 		sess.Table("monitor_location")
 		if _, err = sess.Insert(&monitor_locations); err != nil {
 			return err


### PR DESCRIPTION
...will throw a slice out of bounds error. Add a check for that condition and return an explanatory error message.