### PR TITLE
fixes #16 - hide summary/config tabs when creating new endpoint

### DIFF
--- a/src/css/less/rt.less
+++ b/src/css/less/rt.less
@@ -1,5 +1,5 @@
 html {-webkit-font-smoothing:antialiased;
-      -moz-osx-font-smoothing: grayscale;} /* make type beautiful*/
+      -moz-osx-font-smoothing: grayscale;} /* make type beautiful */
 
 /***********************************
 COLUMNS

--- a/src/plugins/raintank/features/partials/endpoints_edit.html
+++ b/src/plugins/raintank/features/partials/endpoints_edit.html
@@ -26,13 +26,13 @@
 	</div>
 
 	<!-- tabs -->
-	<div class="rt-tabs">
+	<div class="rt-tabs" ng-if="endpoint.id">
 		<span class="nonactive"><a href="endpoints/summary/{{endpoint.id}}">Summary</a></span>  <span class="active" ng-hide="!contextSrv.isGrafanaAdmin"><a href="endpoints/edit/{{endpoint.id}}">Configuration</a></span>
 	</div>
 </div>
 
 
-	<form name="endpointForm">
+	<form name="endpointForm" style="margin: 0px; position: relative; display: block; min-width:400px; max-width: 1320px;">
 
 	<div class="grid">
 		<div class="grid-full rt-box">


### PR DESCRIPTION
Added if statement that hides the summary/config tabs if an endpoint does not have an ID (like when creating a new endpoint). 

Also put max-width on config forms to match the other pages.