### PR TITLE
backend changes to allow querying events by endpoint. issue #44

### DIFF
--- a/pkg/events/raintank.go
+++ b/pkg/events/raintank.go
@@ -12,7 +12,7 @@ type MonitorPayload struct {
 	Id            int64                  `json:"id"`
 	OrgId         int64                  `json:"org_id"`
 	EndpointId    int64                  `json:"endpoint_id"`
-	Namespace     string                 `json:"namespace"`
+	EndpointSlug  string                 `json:"endpoint_slug"`
 	MonitorTypeId int64                  `json:"monitor_type_id"`
 	CollectorIds  []int64                `json:"collector_ids"`
 	CollectorTags []string               `json:"collector_tags"`
@@ -49,6 +49,7 @@ type EndpointPayload struct {
 	Id    int64    `json:"id"`
 	OrgId int64    `json:"org_id"`
 	Name  string   `json:"name"`
+	Slug  string   `json:"slug"`
 	Tags  []string `json:"tags"`
 }
 
@@ -67,6 +68,7 @@ type EndpointRemoved struct {
 	Timestamp time.Time `json:"timestamp"`
 	Id        int64     `json:"id"`
 	Name      string    `json:"name"`
+	Slug      string    `json:"slug"`
 	OrgId     int64     `json:"org_id"`
 	Tags      []string  `json:"tags"`
 }

--- a/pkg/models/endpoint.go
+++ b/pkg/models/endpoint.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"errors"
+	"regexp"
+	"strings"
 	"time"
 )
 
@@ -15,6 +17,7 @@ type Endpoint struct {
 	Id      int64
 	OrgId   int64
 	Name    string
+	Slug    string
 	Created time.Time
 	Updated time.Time
 }
@@ -32,6 +35,7 @@ type EndpointDTO struct {
 	Id    int64    `json:"id"`
 	OrgId int64    `json:"org_id"`
 	Name  string   `json:"name"`
+	Slug  string   `json:"slug"`
 	Tags  []string `json:"tags"`
 }
 
@@ -87,4 +91,11 @@ type GetEndpointHealthByIdQuery struct {
 	Id     int64
 	OrgId  int64
 	Result []*MonitorCollectorState
+}
+
+func (endpoint *Endpoint) UpdateEndpointSlug() {
+	name := strings.ToLower(endpoint.Name)
+	re := regexp.MustCompile("[^\\w ]+")
+	re2 := regexp.MustCompile("\\s")
+	endpoint.Slug = re2.ReplaceAllString(re.ReplaceAllString(name, ""), "-")
 }

--- a/pkg/models/endpoint.go
+++ b/pkg/models/endpoint.go
@@ -97,5 +97,5 @@ func (endpoint *Endpoint) UpdateEndpointSlug() {
 	name := strings.ToLower(endpoint.Name)
 	re := regexp.MustCompile("[^\\w ]+")
 	re2 := regexp.MustCompile("\\s")
-	endpoint.Slug = re2.ReplaceAllString(re.ReplaceAllString(name, ""), "-")
+	endpoint.Slug = re2.ReplaceAllString(re.ReplaceAllString(name, "_"), "-")
 }

--- a/pkg/models/monitor.go
+++ b/pkg/models/monitor.go
@@ -35,7 +35,6 @@ type Monitor struct {
 	Id            int64
 	OrgId         int64
 	EndpointId    int64
-	Namespace     string
 	MonitorTypeId int64
 	Offset        int64
 	Frequency     int64
@@ -80,7 +79,7 @@ type MonitorDTO struct {
 	Id            int64                `json:"id"`
 	OrgId         int64                `json:"org_id"`
 	EndpointId    int64                `json:"endpoint_id"`
-	Namespace     string               `json:"namespace"`
+	EndpointSlug  string               `json:"endpoint_slug"`
 	MonitorTypeId int64                `json:"monitor_type_id" binding:"required"`
 	CollectorIds  []int64              `json:"collector_ids"`
 	CollectorTags []string             `json:"collector_tags"`
@@ -116,7 +115,6 @@ type AddMonitorCommand struct {
 	OrgId         int64                `json:"-"`
 	EndpointId    int64                `json:"endpoint_id" binding:"required"`
 	MonitorTypeId int64                `json:"monitor_type_id" binding:"required"`
-	Namespace     string               `json:"namespace"`
 	CollectorIds  []int64              `json:"collector_ids"`
 	CollectorTags []string             `json:"collector_tags"`
 	Settings      []*MonitorSettingDTO `json:"settings"`
@@ -130,7 +128,6 @@ type UpdateMonitorCommand struct {
 	Id            int64                `json:"id" binding:"required"`
 	EndpointId    int64                `json:"endpoint_id" binding:"required"`
 	OrgId         int64                `json:"-"`
-	Namespace     string               `json:"namespace"`
 	MonitorTypeId int64                `json:"monitor_type_id" binding:"required"`
 	CollectorIds  []int64              `json:"collector_ids"`
 	CollectorTags []string             `json:"collector_tags"`

--- a/pkg/services/sqlstore/endpoint.go
+++ b/pkg/services/sqlstore/endpoint.go
@@ -132,6 +132,7 @@ func AddEndpoint(cmd *m.AddEndpointCommand) error {
 			Created: time.Now(),
 			Updated: time.Now(),
 		}
+		endpoint.UpdateEndpointSlug()
 
 		if _, err := sess.Insert(endpoint); err != nil {
 			return err
@@ -155,6 +156,7 @@ func AddEndpoint(cmd *m.AddEndpointCommand) error {
 			Id:    endpoint.Id,
 			OrgId: endpoint.OrgId,
 			Name:  endpoint.Name,
+			Slug:  endpoint.Slug,
 			Tags:  cmd.Tags,
 		}
 		sess.publishAfterCommit(&events.EndpointCreated{
@@ -162,6 +164,7 @@ func AddEndpoint(cmd *m.AddEndpointCommand) error {
 				Id:    endpoint.Id,
 				OrgId: endpoint.OrgId,
 				Name:  endpoint.Name,
+				Slug:  endpoint.Slug,
 				Tags:  cmd.Tags,
 			},
 			Timestamp: endpoint.Updated,
@@ -201,6 +204,7 @@ func UpdateEndpoint(cmd *m.UpdateEndpointCommand) error {
 			Created: time.Now(),
 			Updated: time.Now(),
 		}
+		endpoint.UpdateEndpointSlug()
 
 		_, err = sess.Id(cmd.Id).Update(endpoint)
 		if err != nil {
@@ -229,6 +233,7 @@ func UpdateEndpoint(cmd *m.UpdateEndpointCommand) error {
 			Id:    cmd.Id,
 			OrgId: endpoint.OrgId,
 			Name:  endpoint.Name,
+			Slug:  endpoint.Slug,
 			Tags:  cmd.Tags,
 		}
 		sess.publishAfterCommit(&events.EndpointUpdated{
@@ -236,6 +241,7 @@ func UpdateEndpoint(cmd *m.UpdateEndpointCommand) error {
 				Id:    cmd.Id,
 				OrgId: endpoint.OrgId,
 				Name:  endpoint.Name,
+				Slug:  endpoint.Slug,
 				Tags:  cmd.Tags,
 			},
 			Timestamp: endpoint.Updated,
@@ -243,6 +249,7 @@ func UpdateEndpoint(cmd *m.UpdateEndpointCommand) error {
 				Id:    lastState.Id,
 				OrgId: lastState.OrgId,
 				Name:  lastState.Name,
+				Slug:  lastState.Slug,
 				Tags:  lastState.Tags,
 			},
 		})
@@ -287,6 +294,7 @@ func DeleteEndpoint(cmd *m.DeleteEndpointCommand) error {
 			Id:        cmd.Id,
 			OrgId:     cmd.OrgId,
 			Name:      q.Result.Name,
+			Slug:      q.Result.Slug,
 		})
 		return err
 	})

--- a/pkg/services/sqlstore/endpoint.go
+++ b/pkg/services/sqlstore/endpoint.go
@@ -22,6 +22,7 @@ type EndpointWithTag struct {
 	Id      int64
 	OrgId   int64
 	Name    string
+	Slug    string
 	Tags    string
 	Created time.Time
 	Updated time.Time
@@ -62,6 +63,7 @@ func GetEndpointByIdTransaction(query *m.GetEndpointByIdQuery, sess *session) er
 		Id:    result.Id,
 		OrgId: result.OrgId,
 		Name:  result.Name,
+		Slug:  result.Slug,
 		Tags:  tags,
 	}
 	return nil
@@ -115,6 +117,7 @@ func GetEndpoints(query *m.GetEndpointsQuery) error {
 			Id:    row.Id,
 			OrgId: row.OrgId,
 			Name:  row.Name,
+			Slug:  row.Slug,
 			Tags:  tags,
 		})
 	}

--- a/pkg/services/sqlstore/migrations/endpoint_mig.go
+++ b/pkg/services/sqlstore/migrations/endpoint_mig.go
@@ -10,7 +10,6 @@ func addEndpointMigration(mg *Migrator) {
 			&Column{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			&Column{Name: "org_id", Type: DB_BigInt, Nullable: false},
 			&Column{Name: "name", Type: DB_NVarchar, Length: 255, Nullable: false},
-			&Column{Name: "slug", Type: DB_NVarchar, Length: 255, Nullable: false},
 			&Column{Name: "created", Type: DB_DateTime, Nullable: false},
 			&Column{Name: "updated", Type: DB_DateTime, Nullable: false},
 		},
@@ -22,6 +21,9 @@ func addEndpointMigration(mg *Migrator) {
 
 	//-------  indexes ------------------
 	addTableIndicesMigrations(mg, "v1", endpointV1)
+
+	slugCol := &Column{Name: "slug", Type: DB_NVarchar, Length: 255, Nullable: false}
+	mg.AddMigration("add slug column to endpoint v1", NewAddColumnMigration(endpointV1, slugCol))
 
 	// add endpoint_tags
 	var endpointTagV1 = Table{

--- a/pkg/services/sqlstore/migrations/endpoint_mig.go
+++ b/pkg/services/sqlstore/migrations/endpoint_mig.go
@@ -10,6 +10,7 @@ func addEndpointMigration(mg *Migrator) {
 			&Column{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			&Column{Name: "org_id", Type: DB_BigInt, Nullable: false},
 			&Column{Name: "name", Type: DB_NVarchar, Length: 255, Nullable: false},
+			&Column{Name: "slug", Type: DB_NVarchar, Length: 255, Nullable: false},
 			&Column{Name: "created", Type: DB_DateTime, Nullable: false},
 			&Column{Name: "updated", Type: DB_DateTime, Nullable: false},
 		},

--- a/pkg/services/sqlstore/migrations/monitor_mig.go
+++ b/pkg/services/sqlstore/migrations/monitor_mig.go
@@ -11,6 +11,7 @@ func addMonitorMigration(mg *Migrator) {
 			&Column{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			&Column{Name: "endpoint_id", Type: DB_BigInt, Nullable: false},
 			&Column{Name: "org_id", Type: DB_BigInt, Nullable: false},
+			&Column{Name: "namespace", Type: DB_NVarchar, Length: 255, Nullable: false},
 			&Column{Name: "monitor_type_id", Type: DB_BigInt, Nullable: false},
 			&Column{Name: "offset", Type: DB_BigInt, Nullable: false},
 			&Column{Name: "frequency", Type: DB_BigInt, Nullable: false},
@@ -22,7 +23,7 @@ func addMonitorMigration(mg *Migrator) {
 			&Column{Name: "updated", Type: DB_DateTime, Nullable: false},
 		}, Indices: []*Index{
 			&Index{Cols: []string{"monitor_type_id"}},
-			&Index{Cols: []string{"org_id", "endpoint_id", "monitor_type_id"}, Type: UniqueIndex},
+			&Index{Cols: []string{"org_id", "namespace", "monitor_type_id"}, Type: UniqueIndex},
 		},
 	}
 

--- a/pkg/services/sqlstore/migrations/monitor_mig.go
+++ b/pkg/services/sqlstore/migrations/monitor_mig.go
@@ -11,7 +11,6 @@ func addMonitorMigration(mg *Migrator) {
 			&Column{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			&Column{Name: "endpoint_id", Type: DB_BigInt, Nullable: false},
 			&Column{Name: "org_id", Type: DB_BigInt, Nullable: false},
-			&Column{Name: "namespace", Type: DB_NVarchar, Length: 255, Nullable: false},
 			&Column{Name: "monitor_type_id", Type: DB_BigInt, Nullable: false},
 			&Column{Name: "offset", Type: DB_BigInt, Nullable: false},
 			&Column{Name: "frequency", Type: DB_BigInt, Nullable: false},
@@ -23,7 +22,7 @@ func addMonitorMigration(mg *Migrator) {
 			&Column{Name: "updated", Type: DB_DateTime, Nullable: false},
 		}, Indices: []*Index{
 			&Index{Cols: []string{"monitor_type_id"}},
-			&Index{Cols: []string{"org_id", "namespace", "monitor_type_id"}, Type: UniqueIndex},
+			&Index{Cols: []string{"org_id", "endpoint_id", "monitor_type_id"}, Type: UniqueIndex},
 		},
 	}
 

--- a/pkg/services/sqlstore/migrator/migrations.go
+++ b/pkg/services/sqlstore/migrator/migrations.go
@@ -64,6 +64,10 @@ type AddColumnMigration struct {
 	column    *Column
 }
 
+func NewAddColumnMigration(table Table, col *Column) *AddColumnMigration {
+	return &AddColumnMigration{tableName: table.Name, column: col}
+}
+
 func (m *AddColumnMigration) Table(tableName string) *AddColumnMigration {
 	m.tableName = tableName
 	return m

--- a/pkg/services/sqlstore/migrator/migrations.go
+++ b/pkg/services/sqlstore/migrator/migrations.go
@@ -2,12 +2,16 @@ package migrator
 
 import (
 	"fmt"
+	"github.com/go-xorm/xorm"
 	"strings"
 )
+
+type OnSuccess func(*xorm.Session) error
 
 type MigrationBase struct {
 	id        string
 	Condition MigrationCondition
+	OnSuccess OnSuccess
 }
 
 func (m *MigrationBase) Id() string {
@@ -20,6 +24,13 @@ func (m *MigrationBase) SetId(id string) {
 
 func (m *MigrationBase) GetCondition() MigrationCondition {
 	return m.Condition
+}
+
+func (m *MigrationBase) ExecOnSuccess(sess *xorm.Session) error {
+	if m.OnSuccess != nil {
+		return m.OnSuccess(sess)
+	}
+	return nil
 }
 
 type RawSqlMigration struct {

--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -134,7 +134,8 @@ func (mg *Migrator) exec(m Migration) error {
 			log.Error(3, "Migrator: exec FAILED migration id: %v, err: %v", m.Id(), err)
 			return err
 		}
-		return nil
+		//run additiona migration code.
+		return m.ExecOnSuccess(sess)
 	})
 
 	if err != nil {

--- a/pkg/services/sqlstore/migrator/types.go
+++ b/pkg/services/sqlstore/migrator/types.go
@@ -2,6 +2,7 @@ package migrator
 
 import (
 	"fmt"
+	"github.com/go-xorm/xorm"
 	"strings"
 )
 
@@ -16,6 +17,7 @@ type Migration interface {
 	Id() string
 	SetId(string)
 	GetCondition() MigrationCondition
+	ExecOnSuccess(*xorm.Session) error
 }
 
 type SQLType string

--- a/public/plugins/raintank/features/endpointConfCtrl.js
+++ b/public/plugins/raintank/features/endpointConfCtrl.js
@@ -255,16 +255,8 @@ function (angular) {
       });
     }
 
-    $scope.slug = function(name) {
-      var label = name.toLowerCase();
-      var re = new RegExp("[^\\w-]+", "g");
-      var re2 = new RegExp("\\s", "g");
-      var slug = label.replace(re, "_").replace(re2, "-");
-      return slug;
-    }
-
     $scope.gotoDashboard = function(endpoint) {
-      $location.path("/dashboard/db/statusboard").search({"var-collector": "All", "var-endpoint": $scope.slug($scope.endpoint.name)});
+      $location.path("/dashboard/db/statusboard").search({"var-collector": "All", "var-endpoint": $scope.endpoint.slug});
     }
 
     $scope.init();

--- a/public/plugins/raintank/features/endpointSummaryCtrl.js
+++ b/public/plugins/raintank/features/endpointSummaryCtrl.js
@@ -116,21 +116,13 @@ function (angular, _) {
       $location.path('/endpoints/summary/'+id);
     }
 
-    $scope.slug = function(name) {
-      var label = name.toLowerCase();
-      var re = new RegExp("[^\\w-]+", "g");
-      var re2 = new RegExp("\\s", "g");
-      var slug = label.replace(re, "_").replace(re2, "-");
-      return slug;
-    }
-
     $scope.gotoDashboard = function(endpoint, type) {
       if (!type) {
         type = 'summary';
       }
       var search = {
         "var-collector": "All",
-        "var-endpoint": $scope.slug($scope.endpoint.name)
+        "var-endpoint": $scope.endpoint.slug
       };
       switch(type) {
         case "summary":

--- a/public/plugins/raintank/features/endpointsCtrl.js
+++ b/public/plugins/raintank/features/endpointsCtrl.js
@@ -162,16 +162,8 @@ function (angular) {
       });
     };
 
-    $scope.slug = function(name) {
-      var label = name.toLowerCase();
-      var re = new RegExp("[^\\w-]+", "g");
-      var re2 = new RegExp("\\s", "g");
-      var slug = label.replace(re, "_").replace(re2, "-");
-      return slug;
-    }
-
     $scope.gotoDashboard = function(endpoint) {
-      $location.path("/dashboard/raintank/rt-endpoint-summary").search({"var-collector": "All", "var-endpoint": $scope.slug(endpoint.name)});
+      $location.path("/dashboard/raintank/rt-endpoint-summary").search({"var-collector": "All", "var-endpoint": endpoint.slug});
     }
 
     var newEndpointModalScope = null;


### PR DESCRIPTION
Store endpoint slug in db. remove the namespace column from monitors
and instead populate the monitor DTO with endpoint_slug fetched via
SQL join on endpoint table.