### PR TITLE
events panel on collector tweak

### DIFF
--- a/public/plugins/raintank/features/partials/collectors_summary.html
+++ b/public/plugins/raintank/features/partials/collectors_summary.html
@@ -81,8 +81,8 @@
 		</div>
 
 		<div class="detailFull" style="display: inline-flex; margin-top: 10px; align-items: center; justify-content: center;">
-		<div style="display: inline-block; background: #1F1F1F; background-image:url(/img/loading-pulse.svg); background-repeat: no-repeat; background-position:center; padding: 0px; line-height: 0;">
-		<iframe src="http://128.199.88.198/dashboard-solo/db/events-sample?panelId=12&fullscreen&from=now-30d&to=now&var-collector={{collector.slug}}" width="1000" height="275" frameborder="0"></iframe>
+		<div style="display: inline-block; background: #1F1F1F; background-image:url(/img/loading-pulse.svg); background-repeat: no-repeat; background-position:center; padding: 0px; line-height: 0; margin-left:10px; margin-right:10px; width:100%;">
+		<iframe src="http://128.199.88.198/dashboard-solo/db/events-sample?panelId=12&fullscreen&from=now-30d&to=now&var-collector={{collector.slug}}" width="100%" height="275" frameborder="0"></iframe>
 		</div>
 		</div>
 	</div>	


### PR DESCRIPTION
events panel on collector summary was hard-coded to be 1000px wide. It will now stretch to 100% based on browser width, with max-width of 1000px and min-width of 400px.