### PR TITLE
collector count in tags was wrong for dynamic footprint config

### DIFF
--- a/public/plugins/raintank/directives/partials/endpointCollectorSelect.html
+++ b/public/plugins/raintank/directives/partials/endpointCollectorSelect.html
@@ -33,7 +33,9 @@
 								{{option.text}}
 								<i ng-class="icon" class="tag-icon icon-rt-collector"></i>
 							</span>
+							<!-- 
 							<span class="collector-dropdown-tag-count">(4)</span>
+							-->
 						</a>
 					</div>
 					<div class="collector-dropdown-container-col">


### PR DESCRIPTION
collector count in tags for dynamic footprint config was hardcoded to 4 instead of the actual number of collectors in a tag. Commented out until can be dynamic.