### PR TITLE
EndpointConfCtrl fixes

### DIFF
--- a/public/plugins/raintank/features/endpointConfCtrl.js
+++ b/public/plugins/raintank/features/endpointConfCtrl.js
@@ -21,6 +21,7 @@ function (angular) {
 
     $scope.init = function() {
       var promises = [];
+      $scope.editor = {index: 0};
       $scope.newEndpointName = "";
       $scope.discovered = false;
       $scope.discoveryInProgress = false;
@@ -406,6 +407,7 @@ function (angular) {
       });
       backendSrv.put('/api/endpoints', payload).then(function(resp) {
         $scope.endpoint = resp;
+        $scope.ignoreChanges = true;
         alertSrv.set("endpoint added", '', 'success', 3000);
         $location.path("endpoints/summary/"+resp.id);
       });

--- a/public/plugins/raintank/features/partials/endpoint_new.html
+++ b/public/plugins/raintank/features/partials/endpoint_new.html
@@ -19,7 +19,7 @@
     </ul> -->
 </topnav>
 
-<div ng-controller="EndpointConfCtrl" ng-init="editor={index:0}">
+<div>
     <div class="rt-page">
         <div class="rt-page-header">
             <i ng-class="icon" class="icon-rt-endpoint" style="font-size:24px;"></i> <h1 class="rt-h1">New Endpoint</h1>
@@ -36,10 +36,10 @@
                         <div class="rt-mini-form-col" style="margin-top: 15px;">
                         <div ng-hide="discovered || discoveryInProgress">
                                 <button type="submit" class="secondaryCTA ButtonTall" ng-click="endpointForm.$valid && discover(endpoint)">Auto Discover</button>
-                            </div>                                                          
+                            </div>
                             <div ng-show="discoveryInProgress">
                                 <svg width="25" height="25" viewBox="0 0 44 44" xmlns="http://www.w3.org/2000/svg" stroke="#13B3D4" class="puff">
-                                    <g fill="none" fill-rule="evenodd" stroke-width="3"> 
+                                    <g fill="none" fill-rule="evenodd" stroke-width="3">
                                         <circle cx="22" cy="22" r="1">
                                             <animate attributeName="r"
                                                 begin="0s" dur="3s"


### PR DESCRIPTION
Removed EndpointConfCtrl from partial as it is already referenced in route, this caused duplicate controllers to be created. 

Does not solve the problem of the unsaved changes modal appearing all the time though. the function pendingChanges returns true in almost all cases, especially when opening an existing endpoint that has 3/4 monitors enabled. 

#137