### PR TITLE
Collector Summary & List Updates

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -239,8 +239,8 @@ graphite_url = http://graphite-api:8888/
 
 #################################### Dashboard JSON files ##########################
 [dashboards.json]
-enabled = false
-path = /var/lib/grafana/dashboards
+enabled = true
+path = public/plugins/raintank/dashboards/litmus
 
 
 [telemetry]

--- a/public/plugins/raintank/features/collectorConfCtrl.js
+++ b/public/plugins/raintank/features/collectorConfCtrl.js
@@ -45,11 +45,11 @@ function (angular, _) {
     $scope.getCollector = function(id) {
       _.forEach($scope.collectors, function(collector) {
         if (collector.id === parseInt(id)) {
-          if (collector.org_id !== contextSrv.user.orgId) {
-            $location.path('/collectors');
-          } else {
-            $scope.collector = collector;
-          }
+          $scope.collector = collector;
+          $scope.collectorUpdates = {
+            "name": collector.name,
+            "public": collector.public
+          };
         }
       });
     };
@@ -77,6 +77,12 @@ function (angular, _) {
 
     $scope.save = function() {
       backendSrv.post('/api/collectors', $scope.collector);
+    };
+
+    $scope.update = function() {
+      $scope.collector.name = $scope.collectorUpdates.name;
+      $scope.collector.public = $scope.collectorUpdates.public;
+      $scope.save();
     };
 
     $scope.add = function() {

--- a/public/plugins/raintank/features/collectorConfCtrl.js
+++ b/public/plugins/raintank/features/collectorConfCtrl.js
@@ -66,7 +66,7 @@ function (angular, _) {
     };
 
     $scope.setCollector = function(id) {
-      $location.path('/collectors/edit/'+id);
+      $location.path('/collectors/summary/'+id);
     };
 
     $scope.remove = function(collector) {

--- a/public/plugins/raintank/features/partials/collectors.html
+++ b/public/plugins/raintank/features/partials/collectors.html
@@ -19,14 +19,18 @@
 		<div class="editor-row">
 			<div class="editor-option">
 				<span class="small">Filter by:</span>
-				<select class="input-medium rt-select-dropdown" style="" ng-model="collector_filter.value">
-					<option value="" label="All Tags" style="color:black">All Collectors</option>
-					<option ng-repeat="t in collectorTags()" value="{{t}}" label="{{t}}" style="color:black">{{t}}</option>
-				</select>
-				<select class="input-medium rt-select-dropdown" style="" ng-model="status_filter.value">
-					<option value="" label="All Statuses" style="color:black">All Statuses</option>
-					<option ng-repeat="s in statuses" value="{{s.value}}" label="{{s.label}}" style="color:black">{{s.label}}</option>
-				</select>
+					<div class="select-input">
+						<select ng-model="collector_filter.value">
+							<option value="" label="All Tags">All Collectors</option>
+							<option ng-repeat="t in collectorTags()" value="{{t}}" label="{{t}}">{{t}}</option>
+						</select>
+					</div>
+					<div class="select-input">
+						<select class="select-input" style="" ng-model="status_filter.value">
+							<option value="" label="All Statuses">All Statuses</option>
+							<option ng-repeat="s in statuses" value="{{s.value}}" label="{{s.label}}">{{s.label}}</option>
+						</select>
+					</div>
 			</div>
 
 			<div style="display: block; padding: 45px 0 0 0;">

--- a/public/plugins/raintank/features/partials/collectors_edit.html
+++ b/public/plugins/raintank/features/partials/collectors_edit.html
@@ -21,13 +21,21 @@
 
 <div style="margin: 10px; position: relative; display: block; min-width:400px; max-width: 1000px;">
 			<!-- page title -->
-	<div class="rt-page-header-area">
+
+    <div class="rt-page-header" ng-if="!collector.id">
+         <i ng-class="icon" class="icon-rt-collector" style="font-size:24px;"></i>
+         <h1 class="rt-h1">Add a new collector</h1>
+    </div>
+
+	<div class="rt-page-header-area" ng-if="collector.id">
+
 		<h1 class="rt-h1">{{collector.name}}</h1>
 
 		<span class="collector_icon public"><i ng-class="icon" class="icon-rt-raintank_icn" style="" ng-if="collector.public == 1" bs-tooltip="'This is a public collector'"></i></span>
 		<span class="collector_icon private"><i ng-class="icon" class="icon-rt-private-collector" style="" ng-if="collector.public == 0" bs-tooltip="'This is a private collector'"></i></span>
 	</div>
-	<div class="editor-row rt-detail-pages">
+    
+	<div class="editor-row rt-detail-pages" ng-if="collector.id">
 		<div class="editor-option">
 			<bootstrap-tagsinput ng-model="collector.tags" tagclass="label rt-label-tag" placeholder="New Tag" on-tags-updated="tagsUpdated()" ></bootstrap-tagsinput>
 		</div>
@@ -37,13 +45,11 @@
 	<div class="rt-tabs" ng-if="collector.id">
 		<span class="nonactive"><a href="collectors/summary/{{collector.id}}">Summary</a></span>  <span class="active" ng-show="collector.org_id == contextSrv.user.orgId"><a href="collectors/edit/{{collector.id}}">Configuration</a></span>
 	</div>
-</div>
-
 
 	<form name="collectorForm" style="margin: 0px; position: relative; display: block; min-width:400px; max-width: 1020px;">
 
 
-		<div class="rt-page-section" style="padding-left: 10px; margin-top: 35px;">
+<!-- 		<div class="rt-page-section" style="padding-left: 10px; margin-top: 35px;">
 			<div class="rt-mini-form new-endpoint-domain-form">
 				<div class="rt-mini-form-col">
 					<label class="rt-form-label-medium">Collector Name</label>
@@ -63,8 +69,33 @@
 					</div>
 				</div>
 			</div>
-		</div>
+		</div> -->
+
+        <div class="rt-page-section" style="padding-left: 10px; margin-top: 35px;">
+          <div class="rt-mini-form new-endpoint-domain-form">
+            <div class="rt-mini-form-col">
+              <label class="rt-form-label-medium">Collector Name</label>
+			  <input type="text" class="rt-form-input" ng-model="collector.name" required="">
+            </div>
+			<div class="checkbox-check-enabled" ng-if="contextSrv.isGrafanaAdmin">
+				<input class="rt-modal" id="collector-public"type="checkbox" ng-model="collector.public">
+				<label for="collector-public" class="rt-modal rt-body-copy"> Public?</label>
+			</div>            
+            <div class="rt-mini-form-col" style="margin-top: 15px;">
+              <div>
+				<div class="editor-row">
+					<button type="submit" class="secondaryCTA" ng-click="save()" ng-show="collector.id">Update Collector</button>
+					<button type="submit" class="secondaryCTA" ng-click="add()" ng-hide="collector.id">Create Collector</button>
+				</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
 	</form>
+</div>
+
+<div style="padding-bottom: 100px;"></div>
 
 
 

--- a/public/plugins/raintank/features/partials/collectors_edit.html
+++ b/public/plugins/raintank/features/partials/collectors_edit.html
@@ -84,8 +84,8 @@
             <div class="rt-mini-form-col" style="margin-top: 15px;">
               <div>
 				<div class="editor-row">
-					<button type="submit" class="secondaryCTA" ng-click="save()" ng-show="collector.id">Update Collector</button>
-					<button type="submit" class="secondaryCTA" ng-click="add()" ng-hide="collector.id">Create Collector</button>
+					<button type="submit" class="secondaryCTA" ng-click="save()" ng-if="collector.id">Update Collector</button>
+					<button type="submit" class="secondaryCTA" ng-click="add()" ng-if="!collector.id">Create Collector</button>
 				</div>
               </div>
             </div>

--- a/public/plugins/raintank/features/partials/collectors_summary.html
+++ b/public/plugins/raintank/features/partials/collectors_summary.html
@@ -31,7 +31,7 @@
 		<span class="collector_icon public"><i ng-class="icon" class="icon-rt-raintank_icn" style="" ng-if="collector.public" bs-tooltip="'This is a public collector'"></i></span>
 		<span class="collector_icon private"><i ng-class="icon" class="icon-rt-private-collector" style="" ng-if="!collector.public" bs-tooltip="'This is a private collector'"></i></span>
 	</div>
-	<div class="editor-row rt-detail-pages">
+	<div class="editor-row rt-detail-pages" ng-controller="CollectorSummaryCtrl">
 		<div class="editor-option">
 			<bootstrap-tagsinput ng-model="collector.tags" tagclass="label rt-label-tag" placeholder="New Tag" on-tags-updated="tagsUpdated()" ></bootstrap-tagsinput>
 		</div>
@@ -39,17 +39,27 @@
 
 	<!-- tabs -->
 	<div class="rt-tabs">
-		<span class="active"><a href="collectors/summary/{{collector.id}}">Summary</a></span>  <span class="nonactive" ng-show="collector.org_id == contextSrv.user.orgId"><a href="collectors/edit/{{collector.id}}">Configuration</a></span>
+		<span class="active"><a href="collectors/summary/{{collector.id}}">Summary</a></span>  
+<!-- 		<span class="nonactive" ng-show="collector.org_id == contextSrv.user.orgId">
+			<a href="collectors/edit/{{collector.id}}">Configuration</a>
+		</span> -->
 	</div>
 </div>
 
 <form name="collectorForm">
 	<div class="detailContainer">
-		<div class="detailColumn detailLeft">
+		<div class="detailColumn detailLeft" ng-controller="CollectorSummaryCtrl">
 		<div class="rt-box clearBack oneCol">
 				<span><a class="superCTA" ng-click="gotoDashboard(collector)">Go to {{collector.name}} Dashboard <i ng-class="icon" class="icon-rt-dashboard"></i></a></span>
 			</div>
 			<div class="rt-box">
+				<div class="rt-box-header">Collector Details
+					<div style="float: right; display: inline;">
+						<div style="display: inline; margin-left:6px;">
+							<a ng-click="gotoDashboard(collector)"><i ng-class="icon" class="dashboard-icon icon-rt-jump-to-dashboard" bs-tooltip="'Go to {{collector.name}} dashboard'"></i></a>
+						</div>
+					</div>
+				</div>
 				<div class="rt-box-body no-padding" style="min-height: 50px">
 					<div class="collectorCurrentStatus">
 						<div class="rt-summary-status">
@@ -74,7 +84,29 @@
 		</div>
 		<div class="detailColumn detailRight">
 			<div class="rt-box clearBack twoCol">
-				<span><a class="superCTA" ng-click="gotoDashboard(collector)">Go to {{collector.name}} Dashboard <i ng-class="icon" class="icon-rt-dashboard"></i></a></span>
+				<div class="rt-box">
+					<div class="rt-box-header">Configuration</div>
+					<div class="rt-box-body no-padding" style="min-height: 50px">
+						<div class="rt-mini-form new-endpoint-domain-form collectorCurrentStatus">
+				            <div class="rt-mini-form-col">
+				              <label class="rt-form-label-medium">Collector Name</label>
+							  <input type="text" class="rt-form-input" ng-model="collector.name" required="">
+				            </div>
+							<div class="checkbox-check-enabled" ng-if="contextSrv.isGrafanaAdmin" style="padding: 15px 0;">
+								<input class="rt-modal" id="collector-public"type="checkbox" ng-model="collector.public">
+								<label for="collector-public" class="rt-modal rt-body-copy"> Public?</label>
+							</div>            
+				            <div class="rt-mini-form-col" style="margin-top: 15px; display: block;">
+				              <div>
+								<div class="editor-row">
+									<button type="submit" class="secondaryCTA" ng-click="save()" ng-if="collector.id">Update Collector</button>
+									<button type="submit" class="secondaryCTA" ng-click="add()" ng-if="!collector.id">Create Collector</button>
+								</div>
+				              </div>
+				            </div>
+				          </div>
+				    </div>
+				</div>
 			</div>
 
 

--- a/public/plugins/raintank/features/partials/collectors_summary.html
+++ b/public/plugins/raintank/features/partials/collectors_summary.html
@@ -31,15 +31,15 @@
 		<span class="collector_icon public"><i ng-class="icon" class="icon-rt-raintank_icn" style="" ng-if="collector.public" bs-tooltip="'This is a public collector'"></i></span>
 		<span class="collector_icon private"><i ng-class="icon" class="icon-rt-private-collector" style="" ng-if="!collector.public" bs-tooltip="'This is a private collector'"></i></span>
 	</div>
-	<div class="editor-row rt-detail-pages" ng-controller="CollectorSummaryCtrl">
+	<div class="editor-row rt-detail-pages">
 		<div class="editor-option">
-			<bootstrap-tagsinput ng-model="collector.tags" tagclass="label rt-label-tag" placeholder="New Tag" on-tags-updated="tagsUpdated()" ></bootstrap-tagsinput>
+			<bootstrap-tagsinput ng-model="collector.tags" tagclass="label rt-label-tag" placeholder="New Tag" on-tags-updated="save()" ></bootstrap-tagsinput>
 		</div>
 	</div>
 
 	<!-- tabs -->
 	<div class="rt-tabs">
-		<span class="active"><a href="collectors/summary/{{collector.id}}">Summary</a></span>  
+		<span class="active"><a href="collectors/summary/{{collector.id}}">Summary</a></span>
 <!-- 		<span class="nonactive" ng-show="collector.org_id == contextSrv.user.orgId">
 			<a href="collectors/edit/{{collector.id}}">Configuration</a>
 		</span> -->
@@ -48,7 +48,7 @@
 
 <form name="collectorForm">
 	<div class="detailContainer">
-		<div class="detailColumn detailLeft" ng-controller="CollectorSummaryCtrl">
+		<div class="detailColumn detailLeft">
 		<div class="rt-box clearBack oneCol">
 				<span><a class="superCTA" ng-click="gotoDashboard(collector)">Go to {{collector.name}} Dashboard <i ng-class="icon" class="icon-rt-dashboard"></i></a></span>
 			</div>
@@ -82,7 +82,7 @@
 
 
 		</div>
-		<div class="detailColumn detailRight">
+		<div class="detailColumn detailRight" ng-if="collector.org_id === contextSrv.user.orgId">
 			<div class="rt-box clearBack twoCol">
 				<div class="rt-box">
 					<div class="rt-box-header">Configuration</div>
@@ -90,16 +90,16 @@
 						<div class="rt-mini-form new-endpoint-domain-form collectorCurrentStatus">
 				            <div class="rt-mini-form-col">
 				              <label class="rt-form-label-medium">Collector Name</label>
-							  <input type="text" class="rt-form-input" ng-model="collector.name" required="">
+							  <input type="text" class="rt-form-input" ng-model="collectorUpdates.name" required="">
 				            </div>
 							<div class="checkbox-check-enabled" ng-if="contextSrv.isGrafanaAdmin" style="padding: 15px 0;">
-								<input class="rt-modal" id="collector-public"type="checkbox" ng-model="collector.public">
+								<input class="rt-modal" id="collector-public"type="checkbox" ng-model="collectorUpdates.public">
 								<label for="collector-public" class="rt-modal rt-body-copy"> Public?</label>
-							</div>            
+							</div>
 				            <div class="rt-mini-form-col" style="margin-top: 15px; display: block;">
 				              <div>
 								<div class="editor-row">
-									<button type="submit" class="secondaryCTA" ng-click="save()" ng-if="collector.id">Update Collector</button>
+									<button type="submit" class="secondaryCTA" ng-click="update()" ng-if="collector.id">Update Collector</button>
 									<button type="submit" class="secondaryCTA" ng-click="add()" ng-if="!collector.id">Create Collector</button>
 								</div>
 				              </div>

--- a/public/plugins/raintank/routes/all.js
+++ b/public/plugins/raintank/routes/all.js
@@ -14,7 +14,7 @@ function (angular) {
       })
       .when('/collectors/summary/:id', {
         templateUrl: 'plugins/raintank/features/partials/collectors_summary.html',
-        controller : 'CollectorSummaryCtrl',
+        controller : 'CollectorConfCtrl',
       })
       .when('/collectors/edit/:id', {
         templateUrl: 'plugins/raintank/features/partials/collectors_edit.html',


### PR DESCRIPTION
Updates in this PR:

- Removed Config tab temporarily.
- Moved config to the Summary tab.
- Changed main controller on Collector Summary from ```CollectorSummaryCtrl``` to ```CollectorConfCtrl```
- Added ```ng-controller=CollectorSummaryCtrl``` where necessary. 
- Changed select boxes on Collector List to cross-browser friendly styles.

Needs:
- A more graceful way of handling the multi-controller situation in Collector Summary (related to Issue https://github.com/raintank/grafana/issues/206)
- When adding a new collector, the form submits and redirects to Summary instead of Edit. 