### PR TITLE
rework statsd instrumentation for alerting

### DIFF
--- a/alerting.json
+++ b/alerting.json
@@ -168,8 +168,8 @@
             {
               "column": "value",
               "function": "mean",
-              "query": "select mean(value) from \"stats.timers.grafana.alert-dispatcher.get-schedules.count_ps\" where $timeFilter group by time($interval) fill(0) order asc",
-              "series": "stats.timers.grafana.alert-dispatcher.get-schedules.count_ps",
+              "query": "select mean(value) from \"stats.grafana.alert-dispatcher.num-getschedules\" where $timeFilter group by time($interval) fill(0) order asc",
+              "series": "stats.grafana.alert-dispatcher.num-getschedules",
               "target": "",
               "fill": "0",
               "interval": "1s"
@@ -526,8 +526,8 @@
               "target": "",
               "function": "mean",
               "column": "value",
-              "series": "stats.timers.grafana.alert-executor.consider-job.original-todo.count_ps",
-              "query": "select mean(value) from \"stats.timers.grafana.alert-executor.consider-job.original-todo.count_ps\" where $timeFilter group by time($interval) fill(0) order asc",
+              "series": "stats.grafana.alert-executor.original-todo",
+              "query": "select mean(value) from \"stats.grafana.alert-executor.original-todo\" where $timeFilter group by time($interval) fill(0) order asc",
               "alias": "todo",
               "interval": "1s",
               "fill": "0",
@@ -537,8 +537,8 @@
               "target": "",
               "function": "mean",
               "column": "value",
-              "series": "stats.timers.grafana.alert-executor.consider-job.already-done.count_ps",
-              "query": "select mean(value) from \"stats.timers.grafana.alert-executor.consider-job.already-done.count_ps\" where $timeFilter group by time($interval) fill(0) order asc",
+              "series": "stats.grafana.alert-executor.already-done",
+              "query": "select mean(value) from \"stats.grafana.alert-executor.already-done\" where $timeFilter group by time($interval) fill(0) order asc",
               "alias": "already done",
               "interval": "1s",
               "fill": "0"

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/Dieterbe/profiletrigger/heap"
-	"github.com/Dieterbe/statsd-go"
 	"github.com/grafana/grafana/pkg/alerting"
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/cmd"
@@ -26,6 +25,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/social"
+	"github.com/grafana/grafana/pkg/statsdmetric"
 )
 
 var version = "master"
@@ -78,13 +78,12 @@ func main() {
 	elasticstore.Init()
 	api.InitCollectorController()
 
-	s, err := statsd.NewClient(setting.StatsdEnabled, setting.StatsdAddr, "grafana.")
+	err := statsdmetric.NewClient(setting.StatsdEnabled, setting.StatsdAddr, "grafana.")
 	if err != nil {
 		log.Error(3, "Statsd client:", err)
 	}
-	// for now only alerting uses statsd, but soon other packages will too.
-	alerting.Stat = s
 
+	alerting.Init()
 	alerting.Construct()
 
 	if err := notifications.Init(); err != nil {

--- a/pkg/alerting/init.go
+++ b/pkg/alerting/init.go
@@ -4,16 +4,74 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/Dieterbe/statsd-go"
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/services/rabbitmq"
 	"github.com/grafana/grafana/pkg/setting"
+	sm "github.com/grafana/grafana/pkg/statsdmetric"
 	"github.com/hashicorp/golang-lru"
 	"github.com/streadway/amqp"
 )
 
-var Stat, _ = statsd.NewClient(false, "", "")
+// TODO metric for executors running
+
+var jobQueueInternalItems sm.Gauge
+var jobQueueInternalSize sm.Gauge
+var tickQueueItems sm.Gauge
+var tickQueueSize sm.Gauge
+var dispatcherJobsSkippedDueToSlowJobQueue sm.Count
+var dispatcherTicksSkippedDueToSlowTickQueue sm.Count
+
+var dispatcherGetSchedules sm.Timer
+var dispatcherNumGetSchedules sm.Count
+var dispatcherJobSchedulesSeen sm.Count
+var dispatcherJobsScheduled sm.Count
+
+var executorConsiderJobAlreadyDone sm.Timer
+var executorConsiderJobOriginalTodo sm.Timer
+
+var executorNumAlreadyDone sm.Count
+var executorNumOriginalTodo sm.Count
+var executorAlertOutcomesOk sm.Count
+var executorAlertOutcomesWarn sm.Count
+var executorAlertOutcomesCrit sm.Count
+var executorAlertOutcomesUnkn sm.Count
+var executorGraphiteEmptyResponse sm.Count
+
+var executorJobQueryGraphite sm.Timer
+var executorJobParseAndEval sm.Timer
+var executorGraphiteMissingVals sm.Meter
+
+// Init initalizes all metrics
+// run this function when statsd is ready, so we can create the series
+func Init() {
+	jobQueueInternalItems = sm.NewGauge("alert-jobqueue-internal.items", 0)
+	jobQueueInternalSize = sm.NewGauge("alert-jobqueue-internal.size", int64(setting.JobQueueSize))
+	tickQueueItems = sm.NewGauge("alert-tickqueue.items", 0)
+	tickQueueSize = sm.NewGauge("alert-tickqueue.size", int64(setting.TickQueueSize))
+	dispatcherJobsSkippedDueToSlowJobQueue = sm.NewCount("alert-dispatcher.jobs-skipped-due-to-slow-jobqueue")
+	dispatcherTicksSkippedDueToSlowTickQueue = sm.NewCount("alert-dispatcher.ticks-skipped-due-to-slow-tickqueue")
+
+	dispatcherGetSchedules = sm.NewTimer("alert-dispatcher.get-schedules", 0)
+	dispatcherNumGetSchedules = sm.NewCount("alert-dispatcher.num-getschedules")
+	dispatcherJobSchedulesSeen = sm.NewCount("alert-dispatcher.job-schedules-seen")
+	dispatcherJobsScheduled = sm.NewCount("alert-dispatcher.jobs-scheduled")
+
+	executorConsiderJobAlreadyDone = sm.NewTimer("alert-executor.consider-job.already-done", 0)
+	executorConsiderJobOriginalTodo = sm.NewTimer("alert-executor.consider-job.original-todo", 0)
+
+	executorNumAlreadyDone = sm.NewCount("alert-executor.already-done")
+	executorNumOriginalTodo = sm.NewCount("alert-executor.original-todo")
+	executorAlertOutcomesOk = sm.NewCount("alert-executor.alert-outcomes.ok")
+	executorAlertOutcomesWarn = sm.NewCount("alert-executor.alert-outcomes.warning")
+	executorAlertOutcomesCrit = sm.NewCount("alert-executor.alert-outcomes.critical")
+	executorAlertOutcomesUnkn = sm.NewCount("alert-executor.alert-outcomes.unknown")
+	executorGraphiteEmptyResponse = sm.NewCount("alert-executor.graphite-emptyresponse")
+
+	executorJobQueryGraphite = sm.NewTimer("alert-executor.job_query_graphite", 0)
+	executorJobParseAndEval = sm.NewTimer("alert-executor.job_parse-and-evaluate", 0)
+	executorGraphiteMissingVals = sm.NewMeter("alert-executor.graphite-missingVals", 0)
+}
 
 func Construct() {
 	cache, err := lru.New(setting.ExecutorLRUSize)
@@ -111,7 +169,7 @@ func distributed(url string, cache *lru.Cache) error {
 		case consumeQueue <- job:
 		default:
 			// TODO: alert when this happens
-			Stat.Increment("alert-dispatcher.jobs-skipped-due-to-slow-jobqueue")
+			dispatcherJobsSkippedDueToSlowJobQueue.Inc(1)
 		}
 		return nil
 	})

--- a/pkg/statsdmetric/counter.go
+++ b/pkg/statsdmetric/counter.go
@@ -1,0 +1,15 @@
+package statsdmetric
+
+type Count struct {
+	key string
+}
+
+func NewCount(key string) Count {
+	c := Count{key}
+	c.Inc(0)
+	return c
+}
+
+func (c Count) Inc(val int64) {
+	Stat.IncrementValue(c.key, val)
+}

--- a/pkg/statsdmetric/gauge.go
+++ b/pkg/statsdmetric/gauge.go
@@ -1,0 +1,15 @@
+package statsdmetric
+
+type Gauge struct {
+	key string
+}
+
+func NewGauge(key string, val int64) Gauge {
+	g := Gauge{key}
+	g.Value(val)
+	return g
+}
+
+func (g Gauge) Value(val int64) {
+	Stat.Gauge(g.key, val)
+}

--- a/pkg/statsdmetric/init.go
+++ b/pkg/statsdmetric/init.go
@@ -1,0 +1,26 @@
+// a metrics class that uses statsd on the backend
+// at some point, we could/might try to unite this with the metrics package
+
+// note that on creation, we automatically send a default value so that:
+// * influxdb doesn't complain when queried for series that don't exist yet, which breaks graphs in grafana
+// * the series show up in your monitoring tool of choice, so you can easily do alerting rules, build dashes etc
+// without having to wait for data. some series would otherwise only be created when things go badly wrong etc.
+// note that for gauges and timers this can create inaccuracies because the true values are hard to predict,
+// but it's worth the trade-off.
+// (for count 0 is harmless and accurate)
+
+package statsdmetric
+
+import (
+	"github.com/Dieterbe/statsd-go"
+)
+
+var Stat, _ = statsd.NewClient(false, "", "")
+
+func NewClient(enabled bool, addr, prefix string) error {
+	client, err := statsd.NewClient(enabled, addr, prefix)
+	if err == nil {
+		Stat = client
+	}
+	return err
+}

--- a/pkg/statsdmetric/meter.go
+++ b/pkg/statsdmetric/meter.go
@@ -1,0 +1,17 @@
+// it's commonly used for non-timer cases where we want these summaries, that's
+// what this is for.
+package statsdmetric
+
+type Meter struct {
+	key string
+}
+
+func NewMeter(key string, val int64) Meter {
+	m := Meter{key}
+	m.Value(val)
+	return m
+}
+
+func (m Meter) Value(val int64) {
+	Stat.Timing(m.key, val)
+}

--- a/pkg/statsdmetric/timer.go
+++ b/pkg/statsdmetric/timer.go
@@ -1,0 +1,21 @@
+package statsdmetric
+
+import "time"
+
+// note that due the preseeding in init, you shouldn't rely on the count and count_ps summaries
+// rather, consider maintaining a separate counter
+// see https://github.com/raintank/grafana/issues/133
+
+type Timer struct {
+	key string
+}
+
+func NewTimer(key string, val time.Duration) Timer {
+	t := Timer{key}
+	t.Value(val)
+	return t
+}
+
+func (t Timer) Value(val time.Duration) {
+	Stat.TimeDuration(t.key, val)
+}


### PR DESCRIPTION
* automatically trigger statsd messages to reasonably assure the series get created
* refactor statsd metrics package to be more generic, we might merge
  into other metrics package later.
* use seperate metrics to track rates for timers to avoid incorrect
  numbers. fix #133