### PR TITLE
load and persist offset in mysql

### DIFF
--- a/pkg/alerting/offset.go
+++ b/pkg/alerting/offset.go
@@ -1,0 +1,41 @@
+package alerting
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/log"
+	m "github.com/grafana/grafana/pkg/models"
+)
+
+func LoadOrSetOffset() int {
+	query := m.GetAlertSchedulerValueQuery{
+		Id: "offset",
+	}
+	err := bus.Dispatch(&query)
+	if err != nil {
+		panic(fmt.Sprintf("failure querying for current offset: %q", err))
+	}
+	if query.Result == "" {
+		log.Debug("initializing offset to default value of 30 seconds.")
+		setOffset(30)
+		return 30
+	}
+	i, err := strconv.Atoi(query.Result)
+	if err != nil {
+		panic(fmt.Sprintf("failure reading in offset: %q. input value was: %q", err, query.Result))
+	}
+	return i
+}
+
+func setOffset(offset int) {
+	update := m.UpdateAlertSchedulerValueCommand{
+		Id:    "offset",
+		Value: fmt.Sprintf("%d", offset),
+	}
+	err := bus.Dispatch(&update)
+	if err != nil {
+		log.Error(0, "Could not persist offset: %q", err)
+	}
+}

--- a/pkg/alerting/scheduler.go
+++ b/pkg/alerting/scheduler.go
@@ -17,7 +17,7 @@ var tickQueue = make(chan time.Time, setting.TickQueueSize)
 // (provided jobs get consistently routed to executors)
 func Dispatcher(jobQueue JobQueue) {
 	go dispatchJobs(jobQueue)
-	offset := time.Duration(30) * time.Second                      // for now, for simplicity, let's just wait 30seconds for the data to come in
+	offset := time.Duration(LoadOrSetOffset()) * time.Second
 	lastProcessed := time.Now().Truncate(time.Second).Add(-offset) // TODO: track this in a database or something so we can resume properly
 	ticker := NewTicker(lastProcessed, offset, clock.New())
 	for {

--- a/pkg/models/alert_scheduler_value.go
+++ b/pkg/models/alert_scheduler_value.go
@@ -1,0 +1,16 @@
+package models
+
+type AlertSchedulerValue struct {
+	Id    string
+	Value string
+}
+
+type UpdateAlertSchedulerValueCommand struct {
+	Id    string
+	Value string
+}
+
+type GetAlertSchedulerValueQuery struct {
+	Id     string
+	Result string
+}

--- a/pkg/services/sqlstore/alert_scheduler_value.go
+++ b/pkg/services/sqlstore/alert_scheduler_value.go
@@ -1,0 +1,46 @@
+package sqlstore
+
+import (
+	"github.com/go-xorm/xorm"
+
+	"github.com/grafana/grafana/pkg/bus"
+	m "github.com/grafana/grafana/pkg/models"
+)
+
+func init() {
+	bus.AddHandler("sql", UpdateAlertSchedulerValue)
+	bus.AddHandler("sql", GetAlertSchedulerValue)
+}
+
+func GetAlertSchedulerValue(query *m.GetAlertSchedulerValueQuery) error {
+	rawSql := "SELECT value from alert_scheduler_value where id=?"
+	results, err := x.Query(rawSql, query.Id)
+
+	if err != nil {
+		return err
+	}
+
+	if len(results) == 0 {
+		return nil
+	}
+
+	query.Result = string(results[0]["value"])
+	return nil
+}
+
+func UpdateAlertSchedulerValue(cmd *m.UpdateAlertSchedulerValueCommand) error {
+	return inTransaction(func(sess *xorm.Session) error {
+
+		entity := m.AlertSchedulerValue{
+			Id:    cmd.Id,
+			Value: cmd.Value,
+		}
+
+		affected, err := sess.Update(&entity)
+		if err == nil && affected == 0 {
+			_, err = sess.Insert(&entity)
+		}
+
+		return err
+	})
+}

--- a/pkg/services/sqlstore/migrations/alert_scheduler_value.go
+++ b/pkg/services/sqlstore/migrations/alert_scheduler_value.go
@@ -1,0 +1,16 @@
+package migrations
+
+import . "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+func addAlertSchedulerValueMigration(mg *Migrator) {
+
+	var alertSchedV1 = Table{
+		Name: "alert_scheduler_value",
+		Columns: []*Column{
+			{Name: "id", Type: DB_Varchar, Length: 255, IsPrimaryKey: true},
+			{Name: "value", Type: DB_Varchar, Length: 255, Nullable: false},
+		},
+	}
+	mg.AddMigration("create alert_scheduler_value table v1", NewAddTableMigration(alertSchedV1))
+
+}

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -19,6 +19,7 @@ func AddMigrations(mg *Migrator) {
 	addMonitorMigration(mg)
 	addEndpointMigration(mg)
 	addDashboardSnapshotMigrations(mg)
+	addAlertSchedulerValueMigration(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {


### PR DESCRIPTION
@torkelo how does this commit look?
this lets the app read and write the offset value to/from mysql.

the main missing piece now is updating the offset in the code runtime as well as mysql.
(at some point we'll have a tool that automatically figures out the best offset at all times and updates grafana accordingly, as well as the database because the value needs to be persisted).
i see two solutions:

A) api call to grafana, grafana updates offset in memory and updates mysql. but only the site admin should be able to call the api call, and it should be easy to do this from curl in a crontab on the server or something, as well as a go program

B) update the offset in mysql. grafana could have a loop that queries every second to load the most recent offset config value.
