### PR TITLE
WIP: track last state change. see #331

### DIFF
--- a/pkg/models/monitor.go
+++ b/pkg/models/monitor.go
@@ -67,6 +67,7 @@ type Monitor struct {
 	Enabled        bool
 	State          CheckEvalResult
 	StateChange    time.Time
+	StateCheck     time.Time
 	Settings       []*MonitorSettingDTO
 	HealthSettings *MonitorHealthSettingDTO
 	Created        time.Time
@@ -124,6 +125,7 @@ type MonitorForAlertDTO struct {
 	Enabled         bool
 	State           CheckEvalResult
 	StateChange     time.Time
+	StateCheck      time.Time
 	Settings        []*MonitorSettingDTO
 	HealthSettings  *MonitorHealthSettingDTO
 	Created         time.Time
@@ -142,6 +144,7 @@ type MonitorDTO struct {
 	Collectors      []int64                  `json:"collectors"`
 	State           CheckEvalResult          `json:"state"`
 	StateChange     time.Time                `json:"state_change"`
+	StateCheck      time.Time                `json:"state_check"`
 	Settings        []*MonitorSettingDTO     `json:"settings"`
 	HealthSettings  *MonitorHealthSettingDTO `json:"health_settings"`
 	Frequency       int64                    `json:"frequency"`

--- a/pkg/services/sqlstore/migrations/monitor_mig.go
+++ b/pkg/services/sqlstore/migrations/monitor_mig.go
@@ -257,4 +257,9 @@ func addMonitorMigration(mg *Migrator) {
 		return nil
 	}
 	mg.AddMigration("monitor add alerts v1", migration)
+
+	migration = NewAddColumnMigration(monitorV3, &Column{
+		Name: "state_check", Type: DB_DateTime, Nullable: false,
+	})
+	mg.AddMigration("monitor add state_check v1", migration)
 }

--- a/pkg/services/sqlstore/monitor.go
+++ b/pkg/services/sqlstore/monitor.go
@@ -2,13 +2,14 @@ package sqlstore
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/events"
 	"github.com/grafana/grafana/pkg/log"
 	m "github.com/grafana/grafana/pkg/models"
-	"strconv"
-	"strings"
-	"time"
 )
 
 func init() {
@@ -34,6 +35,7 @@ type MonitorWithCollectorDTO struct {
 	TagCollectors   string
 	State           m.CheckEvalResult
 	StateChange     time.Time
+	StateCheck      time.Time
 	Settings        []*m.MonitorSettingDTO
 	HealthSettings  *m.MonitorHealthSettingDTO //map[string]int //note: wish we could use m.MonitorHealthSettingDTO directly, but xorm doesn't unmarshal to structs?
 	Frequency       int64
@@ -132,6 +134,7 @@ WHERE monitor.id=?
 		Collectors:      mergedCollectors,
 		State:           result.State,
 		StateChange:     result.StateChange,
+		StateCheck:      result.StateCheck,
 		Settings:        result.Settings,
 		HealthSettings:  result.HealthSettings,
 		Frequency:       result.Frequency,
@@ -298,6 +301,7 @@ FROM monitor
 			Collectors:      mergedCollectors,
 			State:           row.State,
 			StateChange:     row.StateChange,
+			StateCheck:      row.StateCheck,
 			Settings:        row.Settings,
 			HealthSettings:  row.HealthSettings,
 			Frequency:       row.Frequency,
@@ -513,6 +517,7 @@ func addMonitorTransaction(cmd *m.AddMonitorCommand, sess *session) error {
 		Enabled:        cmd.Enabled,
 		State:          -1,
 		StateChange:    time.Now(),
+		StateCheck:     time.Now(),
 	}
 	if _, err := sess.Insert(mon); err != nil {
 		return err
@@ -580,6 +585,7 @@ func addMonitorTransaction(cmd *m.AddMonitorCommand, sess *session) error {
 		Enabled:        mon.Enabled,
 		State:          mon.State,
 		StateChange:    mon.StateChange,
+		StateCheck:     mon.StateCheck,
 		Offset:         mon.Offset,
 		Updated:        mon.Updated,
 	}
@@ -707,6 +713,7 @@ func UpdateMonitor(cmd *m.UpdateMonitorCommand) error {
 			Enabled:        cmd.Enabled,
 			State:          lastState.State,
 			StateChange:    lastState.StateChange,
+			StateCheck:     lastState.StateCheck,
 			Frequency:      cmd.Frequency,
 		}
 


### PR DESCRIPTION
for some reason, getting this error:
```
2015/07/17 17:33:47 [D] Migrator: Skipping migration: insert dns.name type_settings into monitor_type_setting table, Already executed
2015/07/17 17:33:47 [D] Migrator: Skipping migration: insert dns.type type_settings into monitor_type_setting table, Already executed
2015/07/17 17:33:47 [D] Migrator: Skipping migration: insert dns.server type_settings into monitor_type_setting table, Already executed
2015/07/17 17:33:47 [D] Migrator: Skipping migration: insert dns.port type_settings into monitor_type_setting table, Already executed
2015/07/17 17:33:47 [D] Migrator: Skipping migration: insert dns.protocol type_settings into monitor_type_setting table, Already executed
2015/07/17 17:33:47 [D] Migrator: Skipping migration: create monitor_collector table, Already executed
2015/07/17 17:33:47 [D] Migrator: Skipping migration: create index IDX_monitor_collector_monitor_id_collector_id - v1, Already executed
2015/07/17 17:33:47 [D] Migrator: Skipping migration: create monitor_collector_tag table v1, Already executed
2015/07/17 17:33:47 [D] Migrator: Skipping migration: create index IDX_monitor_collector_tag_monitor_id - v1, Already executed
2015/07/17 17:33:47 [D] Migrator: Skipping migration: create index UQE_monitor_collector_tag_monitor_id_tag - v1, Already executed
2015/07/17 17:33:47 [D] Migrator: Executing SQL: 
 alter table `monitor` ADD COLUMN `health_settings` VARCHAR(2048) NULL  

2015/07/17 17:33:47 [I] Migrator: exec migration id: monitor add alerts v1
2015/07/17 17:33:47 [migrator.go:134 func·001()] [E] Migrator: exec FAILED migration id: monitor add alerts v1, err: Error 1060: Duplicate column name 'health_settings'
2015/07/17 17:33:47 [log.go:75 Fatal()] [E] fail to initialize orm engine: Sqlstore::Migration failed err: Error 1060: Duplicate column name 'health_settings'

```