### PR TITLE
fix monitor state change behavior

### DIFF
--- a/pkg/alerting/alerting_executor_test.go
+++ b/pkg/alerting/alerting_executor_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"bosun.org/graphite"
-	m "github.com/grafana/grafana/pkg/models"
 	"github.com/hashicorp/golang-lru"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -42,7 +41,6 @@ func TestExecutor(t *testing.T) {
 		}
 		jobAt := func(ts int64) *Job {
 			return &Job{
-				State: m.EvalResultUnknown,
 				Definition: CheckDef{
 					CritExpr: `graphite("foo", "2m", "", "")`,
 					WarnExpr: "0",

--- a/pkg/alerting/schedule.go
+++ b/pkg/alerting/schedule.go
@@ -26,7 +26,6 @@ type Job struct {
 	Notifications   m.MonitorNotificationSetting
 	Freq            int64
 	Offset          int64 // offset on top of "even" minute/10s/.. intervals
-	State           m.CheckEvalResult
 	Definition      CheckDef
 	GeneratedAt     time.Time
 	LastPointTs     time.Time
@@ -152,7 +151,6 @@ func buildJobForMonitor(monitor *m.MonitorForAlertDTO) *Job {
 		OrgId:           monitor.OrgId,
 		Freq:            monitor.Frequency,
 		Offset:          monitor.Offset,
-		State:           monitor.State,
 		Definition: CheckDef{
 			CritExpr: b.String(),
 			WarnExpr: "0", // for now we have only good or bad. so only crit is needed

--- a/pkg/models/monitor.go
+++ b/pkg/models/monitor.go
@@ -122,7 +122,6 @@ type MonitorForAlertDTO struct {
 	Offset          int64
 	Frequency       int64
 	Enabled         bool
-	State           CheckEvalResult
 	StateChange     time.Time
 	Settings        []*MonitorSettingDTO
 	HealthSettings  *MonitorHealthSettingDTO
@@ -202,9 +201,10 @@ type DeleteMonitorCommand struct {
 }
 
 type UpdateMonitorStateCommand struct {
-	Id      int64
-	State   CheckEvalResult
-	Updated time.Time
+	Id       int64
+	State    CheckEvalResult
+	Updated  time.Time
+	Affected int
 }
 
 // ---------------------


### PR DESCRIPTION
only process state change if it we could persist it. fix #323

do not compare against state at job creation time, which can be stale
rather, update state if it's different, and newer in a transaction. fix #291 

as opposed to AJ's suggestion in #323, 
i decided to use an affected field instead of returning an error.
since out-of-order and same-state (no update) results are an acceptable part of the design, I thought it would be too confusing to have them show up as errors (in code, in logs, in metrics,..)
as discussed though, if no update (e.g. due to state_change being more recent) we treat this as a nil error (instead of a fatal one) also causing the job not to be re-queued (unless further processing fails