### PR TITLE
supply monitor settings in job

### DIFF
--- a/pkg/alerting/executor.go
+++ b/pkg/alerting/executor.go
@@ -179,6 +179,7 @@ func execute(fn GraphiteReturner, job *Job, cache *lru.Cache) error {
 					Data: map[string]interface{}{
 						"Endpoint":   job.EndpointSlug,
 						"EndpointId": job.EndpointId,
+						"Settings":   job.Settings,
 						"CheckType":  job.MonitorTypeName,
 						"State":      res.String(),
 						"Timestamp":  job.LastPointTs,

--- a/pkg/alerting/schedule.go
+++ b/pkg/alerting/schedule.go
@@ -22,6 +22,7 @@ type Job struct {
 	MonitorId       int64
 	EndpointId      int64
 	EndpointSlug    string
+	Settings        map[string]string
 	MonitorTypeName string
 	Notifications   m.MonitorNotificationSetting
 	Freq            int64
@@ -146,6 +147,7 @@ func buildJobForMonitor(monitor *m.MonitorForAlertDTO) *Job {
 		MonitorId:       monitor.Id,
 		EndpointId:      monitor.EndpointId,
 		EndpointSlug:    monitor.EndpointSlug,
+		Settings:        monitor.SettingsMap(),
 		MonitorTypeName: monitor.MonitorTypeName,
 		Notifications:   monitor.HealthSettings.Notifications,
 		OrgId:           monitor.OrgId,

--- a/pkg/models/monitor.go
+++ b/pkg/models/monitor.go
@@ -131,6 +131,14 @@ type MonitorForAlertDTO struct {
 	Updated         time.Time
 }
 
+func (m *MonitorForAlertDTO) SettingsMap() map[string]string {
+	settings := make(map[string]string)
+	for _, s := range m.Settings {
+		settings[s.Variable] = s.Value
+	}
+	return settings
+}
+
 type MonitorDTO struct {
 	Id              int64                    `json:"id"`
 	OrgId           int64                    `json:"org_id"`


### PR DESCRIPTION
so that they can be passed on to notifications
proposed fix for #295 

settings looks like
```
map[string]string{"port":"443", "path":"", "method":"GET", "expectRegex":"", "headers":"Accept-Encoding: gzip\nUser-Agent: raintank collector\n", "validateCert":"true", "host":"www.dnsbelgium.be"}
```