### PR TITLE
fix tag background issue located in raintank-bootstrap-tagsinput.less…

### DIFF
--- a/public/css/less/rt/components/raintank-bootstrap-tagsinput.less
+++ b/public/css/less/rt/components/raintank-bootstrap-tagsinput.less
@@ -5,6 +5,7 @@
   border-radius: 0 !important;
   max-width: 100%;
   line-height: 22px;
+  background-color: transparent;
 
   input {
     display:inline-block;


### PR DESCRIPTION
…  - now set to transparent.
