### PR TITLE
Update rt-endpoint-comparison.json

### DIFF
--- a/public/plugins/raintank/dashboards/litmus/rt-endpoint-comparison.json
+++ b/public/plugins/raintank/dashboards/litmus/rt-endpoint-comparison.json
@@ -697,36 +697,12 @@
     "list": [
       {
         "allFormat": "glob",
-        "current": {
-          "tags": [],
-          "text": "google_com + monkey_id_au",
-          "value": [
-            "google_com",
-            "monkey_id_au"
-          ]
-        },
         "datasource": null,
         "includeAll": false,
         "label": "Endpoint",
         "multi": true,
         "multiFormat": "glob",
         "name": "endpoint",
-        "options": [
-          {
-            "selected": true,
-            "text": "google_com",
-            "value": "google_com"
-          },
-          {
-            "selected": true,
-            "text": "monkey_id_au",
-            "value": "monkey_id_au"
-          },
-          {
-            "text": "raintank_io",
-            "value": "raintank_io"
-          }
-        ],
         "query": "litmus.*",
         "refresh": true,
         "refresh_on_load": false,


### PR DESCRIPTION
Removed defaults that were breaking dash in production.