### PR TITLE
Rabbitmq 400

### DIFF
--- a/pkg/graphite/graphite.go
+++ b/pkg/graphite/graphite.go
@@ -2,7 +2,6 @@
 package graphite
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -135,10 +134,7 @@ type Trace struct {
 }
 
 func (t Trace) String() string {
-	// mangle the response here as well to keep logstash from crashing on
-	// the bare json array
-	resp := bytes.Replace(t.Response, []byte("\n"), []byte("\n> "), -1)
-	return fmt.Sprintf("{Request start:%s end:%s targets:%s url:%s Response:%s}", t.Request.Start, t.Request.End, t.Request.Targets, t.Request.URL, resp)
+	return fmt.Sprintf("{Request start:%s end:%s targets:%s url:%s Response:%s}", t.Request.Start, t.Request.End, t.Request.Targets, t.Request.URL, t.Response)
 }
 
 func (gc *GraphiteContext) Query(r *bgraphite.Request) (bgraphite.Response, error) {

--- a/pkg/graphite/graphite.go
+++ b/pkg/graphite/graphite.go
@@ -2,6 +2,7 @@
 package graphite
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -134,6 +135,9 @@ type Trace struct {
 }
 
 func (t Trace) String() string {
+	// mangle the response here as well to keep logstash from crashing on
+	// the bare json array
+	resp := bytes.Replace(t.Response, []byte("\n"), []byte("\n> "), -1)
 	return fmt.Sprintf("{Request start:%s end:%s targets:%s url:%s Response:%s}", t.Request.Start, t.Request.End, t.Request.Targets, t.Request.URL, t.Response)
 }
 

--- a/pkg/graphite/graphite.go
+++ b/pkg/graphite/graphite.go
@@ -138,7 +138,7 @@ func (t Trace) String() string {
 	// mangle the response here as well to keep logstash from crashing on
 	// the bare json array
 	resp := bytes.Replace(t.Response, []byte("\n"), []byte("\n> "), -1)
-	return fmt.Sprintf("{Request start:%s end:%s targets:%s url:%s Response:%s}", t.Request.Start, t.Request.End, t.Request.Targets, t.Request.URL, t.Response)
+	return fmt.Sprintf("{Request start:%s end:%s targets:%s url:%s Response:%s}", t.Request.Start, t.Request.End, t.Request.Targets, t.Request.URL, resp)
 }
 
 func (gc *GraphiteContext) Query(r *bgraphite.Request) (bgraphite.Response, error) {

--- a/pkg/services/rabbitmq/consumer.go
+++ b/pkg/services/rabbitmq/consumer.go
@@ -103,11 +103,10 @@ func (c *Consumer) getChannel() error {
 			log.Printf("attempting to create new rabbitmq channel.")
 			err := c.getChannel()
 
-			if c.callback != nil {
-				c.consume()
-			}
-
 			if err == nil {
+				if c.callback != nil {
+					c.consume()
+				}
 				break
 			}
 

--- a/pkg/services/rabbitmq/consumer.go
+++ b/pkg/services/rabbitmq/consumer.go
@@ -105,6 +105,9 @@ func (c *Consumer) getChannel() error {
 			if err == nil {
 				break
 			}
+			if c.callback != nil {
+				c.consume()
+			}
 
 			//could not create channel, so lets close the connection
 			// and re-create.

--- a/pkg/services/rabbitmq/consumer.go
+++ b/pkg/services/rabbitmq/consumer.go
@@ -102,11 +102,13 @@ func (c *Consumer) getChannel() error {
 			log.Printf("connection to rabbitmq lost. %s", er.Error())
 			log.Printf("attempting to create new rabbitmq channel.")
 			err := c.getChannel()
-			if err == nil {
-				break
-			}
+
 			if c.callback != nil {
 				c.consume()
+			}
+
+			if err == nil {
+				break
 			}
 
 			//could not create channel, so lets close the connection


### PR DESCRIPTION
This addresses the orphaned consumer rabbitmq issue, and mangles some graphite-api responses we're putting into the logs in such a way that they don't crash logstash.