### PR TITLE
Don't encode Results in json

### DIFF
--- a/pkg/models/endpoint.go
+++ b/pkg/models/endpoint.go
@@ -56,7 +56,7 @@ type AddEndpointCommand struct {
 	Name     string               `json:"name"`
 	Tags     []string             `json:"tags"`
 	Monitors []*AddMonitorCommand `json:"monitors"`
-	Result   *EndpointDTO
+	Result   *EndpointDTO         `json:"-"`
 }
 
 type UpdateEndpointCommand struct {

--- a/pkg/models/monitor.go
+++ b/pkg/models/monitor.go
@@ -190,7 +190,7 @@ type AddMonitorCommand struct {
 	Frequency      int64                    `json:"frequency"`
 	Enabled        bool                     `json:"enabled"`
 	Offset         int64                    `json:"-"`
-	Result         *MonitorDTO
+	Result         *MonitorDTO              `json:"-"`
 }
 
 type UpdateMonitorCommand struct {


### PR DESCRIPTION
this means that we can use the command structures to define settings,
encode them to json, and use them as input data for the http api.


otherwise we'd have to define our own redundant structures.

i tested that i can still add endpoints the normal way (through web ui) but i'ld like @woodsaj to confirm this doesn't break anything else to his knowledge.