### PR TITLE
update the stateChange time to the lastCheck time. fixes #490

### DIFF
--- a/pkg/services/sqlstore/monitor.go
+++ b/pkg/services/sqlstore/monitor.go
@@ -47,8 +47,7 @@ type MonitorWithCollectorDTO struct {
 
 // scrutinizeState fixes the state.  We can't just trust what the database says, we have to verify that the value actually has been updated recently.
 // we can simply do this by requiring that the value has been updated since 2*frequency ago.
-func scrutinizeState(monitor *MonitorWithCollectorDTO) {
-	now := time.Now()
+func scrutinizeState(now time.Time, monitor *MonitorWithCollectorDTO) {
 	if monitor.State == m.EvalResultUnknown {
 		return
 	}
@@ -136,7 +135,7 @@ WHERE monitor.id=?
 		mergedCollectors[count] = k
 		count += 1
 	}
-	scrutinizeState(result)
+	scrutinizeState(time.Now(), result)
 	query.Result = &m.MonitorDTO{
 		Id:              result.Id,
 		EndpointId:      result.EndpointId,
@@ -305,7 +304,7 @@ FROM monitor
 			h.NumCollectors = row.HealthSettings["numCollectors"]
 			h.Steps = row.HealthSettings["steps"]
 		*/
-		scrutinizeState(row)
+		scrutinizeState(time.Now(), row)
 		monitors = append(monitors, &m.MonitorDTO{
 			Id:              row.Id,
 			EndpointId:      row.EndpointId,

--- a/pkg/services/sqlstore/monitor.go
+++ b/pkg/services/sqlstore/monitor.go
@@ -47,16 +47,17 @@ type MonitorWithCollectorDTO struct {
 
 // scrutinizeState fixes the state.  We can't just trust what the database says, we have to verify that the value actually has been updated recently.
 // we can simply do this by requiring that the value has been updated since 2*frequency ago.
-func scrutinizeState(now time.Time, state m.CheckEvalResult, stateCheck time.Time, frequency int64) m.CheckEvalResult {
-	if state == m.EvalResultUnknown {
-		return state
+func scrutinizeState(monitor *MonitorWithCollectorDTO) {
+	now := time.Now()
+	if monitor.State == m.EvalResultUnknown {
+		return
 	}
-	freq := time.Duration(frequency) * time.Second
+	freq := time.Duration(monitor.Frequency) * time.Second
 	oldest := now.Add(-2 * freq)
-	if stateCheck.Before(oldest) {
-		return m.EvalResultUnknown
+	if monitor.StateCheck.Before(oldest) {
+		monitor.State = m.EvalResultUnknown
+		monitor.StateChange = monitor.StateCheck
 	}
-	return state
 }
 
 func GetMonitorById(query *m.GetMonitorByIdQuery) error {
@@ -135,7 +136,7 @@ WHERE monitor.id=?
 		mergedCollectors[count] = k
 		count += 1
 	}
-
+	scrutinizeState(result)
 	query.Result = &m.MonitorDTO{
 		Id:              result.Id,
 		EndpointId:      result.EndpointId,
@@ -146,7 +147,7 @@ WHERE monitor.id=?
 		CollectorIds:    monitorCollectorIds,
 		CollectorTags:   monitorCollectorTags,
 		Collectors:      mergedCollectors,
-		State:           scrutinizeState(time.Now(), result.State, result.StateCheck, result.Frequency),
+		State:           result.State,
 		StateChange:     result.StateChange,
 		StateCheck:      result.StateCheck,
 		Settings:        result.Settings,
@@ -304,7 +305,7 @@ FROM monitor
 			h.NumCollectors = row.HealthSettings["numCollectors"]
 			h.Steps = row.HealthSettings["steps"]
 		*/
-
+		scrutinizeState(row)
 		monitors = append(monitors, &m.MonitorDTO{
 			Id:              row.Id,
 			EndpointId:      row.EndpointId,
@@ -315,7 +316,7 @@ FROM monitor
 			CollectorIds:    monitorCollectorIds,
 			CollectorTags:   monitorCollectorTags,
 			Collectors:      mergedCollectors,
-			State:           scrutinizeState(time.Now(), row.State, row.StateCheck, row.Frequency),
+			State:           row.State,
 			StateChange:     row.StateChange,
 			StateCheck:      row.StateCheck,
 			Settings:        row.Settings,

--- a/pkg/services/sqlstore/monitor_test.go
+++ b/pkg/services/sqlstore/monitor_test.go
@@ -9,32 +9,45 @@ import (
 )
 
 type scenario struct {
-	now        int64
-	inState    m.CheckEvalResult
-	stateCheck int64
-	frequency  int64
-	outState   m.CheckEvalResult
+	now         int64
+	inState     m.CheckEvalResult
+	stateCheck  int64
+	stateChange int64
+	frequency   int64
+	outState    m.CheckEvalResult
 }
 
 func (s scenario) String() string {
 	return fmt.Sprintf("<scenario> now=%d, inState=%s, stateCheck=%d, freq=%d, outState=%s", s.now, s.inState, s.stateCheck, s.frequency, s.outState)
 }
 
+func scrutinizeTest(s scenario) MonitorWithCollectorDTO {
+	mon := MonitorWithCollectorDTO{
+		State:       s.inState,
+		StateCheck:  time.Unix(s.stateCheck, 0),
+		StateChange: time.Unix(s.stateChange, 0),
+		Frequency:   s.frequency,
+	}
+	scrutinizeState(time.Unix(s.now, 0), &mon)
+	return mon
+}
+
 // if exec date is in future, func should be safe and not make changes to state
 func TestScrutinizeStateFuture(t *testing.T) {
 	scenarios := []scenario{
-		{120, m.EvalResultUnknown, 121, 10, m.EvalResultUnknown},
-		{120, m.EvalResultUnknown, 130, 10, m.EvalResultUnknown},
-		{120, m.EvalResultUnknown, 140, 10, m.EvalResultUnknown},
-		{120, m.EvalResultUnknown, 150, 10, m.EvalResultUnknown},
-		{120, m.EvalResultCrit, 121, 10, m.EvalResultCrit},
-		{120, m.EvalResultCrit, 130, 10, m.EvalResultCrit},
-		{120, m.EvalResultCrit, 140, 10, m.EvalResultCrit},
-		{120, m.EvalResultCrit, 150, 10, m.EvalResultCrit},
+		{120, m.EvalResultUnknown, 121, 1, 10, m.EvalResultUnknown},
+		{120, m.EvalResultUnknown, 130, 1, 10, m.EvalResultUnknown},
+		{120, m.EvalResultUnknown, 140, 1, 10, m.EvalResultUnknown},
+		{120, m.EvalResultUnknown, 150, 1, 10, m.EvalResultUnknown},
+		{120, m.EvalResultCrit, 121, 1, 10, m.EvalResultCrit},
+		{120, m.EvalResultCrit, 130, 1, 10, m.EvalResultCrit},
+		{120, m.EvalResultCrit, 140, 1, 10, m.EvalResultCrit},
+		{120, m.EvalResultCrit, 150, 1, 10, m.EvalResultCrit},
 	}
 	for _, s := range scenarios {
-		if res := scrutinizeState(time.Unix(s.now, 0), s.inState, time.Unix(s.stateCheck, 0), s.frequency); res != s.outState {
-			t.Errorf("scenario %s: expected %s - got %s", s, s.outState, res)
+		res := scrutinizeTest(s)
+		if res.State != s.outState {
+			t.Errorf("scenario %s: expected %s - got %s", s, s.outState, res.State)
 		}
 	}
 }
@@ -42,38 +55,39 @@ func TestScrutinizeStateFuture(t *testing.T) {
 var realScenarios = []scenario{
 	// should run at (or shortly after) 107, 117, 127, 137, etc
 	// if last run stays at 117, state should become unknown after 117 + 2*10 = 137
-	{117, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{118, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{119, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{120, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{121, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{122, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{123, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{124, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{125, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{126, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{127, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{128, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{129, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{130, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{131, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{132, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{133, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{134, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{135, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{136, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{137, m.EvalResultCrit, 117, 10, m.EvalResultCrit},
-	{138, m.EvalResultCrit, 117, 10, m.EvalResultUnknown},
-	{139, m.EvalResultCrit, 117, 10, m.EvalResultUnknown},
-	{140, m.EvalResultCrit, 117, 10, m.EvalResultUnknown},
-	{141, m.EvalResultCrit, 117, 10, m.EvalResultUnknown},
+	{117, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{118, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{119, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{120, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{121, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{122, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{123, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{124, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{125, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{126, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{127, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{128, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{129, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{130, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{131, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{132, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{133, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{134, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{135, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{136, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{137, m.EvalResultCrit, 117, 1, 10, m.EvalResultCrit},
+	{138, m.EvalResultCrit, 117, 1, 10, m.EvalResultUnknown},
+	{139, m.EvalResultCrit, 117, 1, 10, m.EvalResultUnknown},
+	{140, m.EvalResultCrit, 117, 1, 10, m.EvalResultUnknown},
+	{141, m.EvalResultCrit, 117, 1, 10, m.EvalResultUnknown},
 }
 
 // crit/warn should become unknown after 2*freq has passed
 func TestScrutinizeStateCritToUnknown(t *testing.T) {
 	for _, s := range realScenarios {
-		if res := scrutinizeState(time.Unix(s.now, 0), s.inState, time.Unix(s.stateCheck, 0), s.frequency); res != s.outState {
-			t.Errorf("scenario %s: expected %s - got %s", s, s.outState, res)
+		res := scrutinizeTest(s)
+		if res.State != s.outState {
+			t.Errorf("scenario %s: expected %s - got %s", s, s.outState, res.State)
 		}
 	}
 }
@@ -81,8 +95,10 @@ func TestScrutinizeStateCritToUnknown(t *testing.T) {
 // unknown should just stay unknown
 func TestScrutinizeStateStayUnknown(t *testing.T) {
 	for _, s := range realScenarios {
-		if res := scrutinizeState(time.Unix(s.now, 0), m.EvalResultUnknown, time.Unix(s.stateCheck, 0), s.frequency); res != m.EvalResultUnknown {
-			t.Errorf("scenario %s: expected %s - got %s", s, s.outState, res)
+		s.inState = m.EvalResultUnknown
+		res := scrutinizeTest(s)
+		if res.State != m.EvalResultUnknown {
+			t.Errorf("scenario %s: expected %s - got %s", s, s.outState, res.State)
 		}
 	}
 }


### PR DESCRIPTION
When returning the data about a monitor, we check when a check last
ran. If the check has not run for a while, we consider the current
state to be unknown.  As well as overriding the state value, this changes
also overrides the stateChange value and sets it to the time of the last check.
This ensures that the timing information provided in the UI is accurate.