### PR TITLE
used quantized start_time in AssertStart. fixes #540

### DIFF
--- a/pkg/alerting/scheduler.go
+++ b/pkg/alerting/scheduler.go
@@ -71,7 +71,8 @@ func dispatchJobs(jobQueue JobQueue) {
 		for _, job := range jobs {
 			job.GeneratedAt = time.Now()
 			job.LastPointTs = lastPointAt
-			job.AssertStart = lastPointAt.Add(-time.Duration(job.AssertStep*(job.AssertSteps-1)) * time.Second)
+			startTs := lastPointAt.Unix() - int64(job.AssertStep*(job.AssertSteps))
+			job.AssertStart = time.Unix((startTs+1)+((startTs+1)%int64(job.AssertStep)), 0)
 
 			jobQueue.Put(job)
 


### PR DESCRIPTION
Graphite-raintank now returns quantized timestamps instead of
raw values.  This is necessary to allow using aggregated data
and is inline with how whisper files work.