### PR TITLE
correctly initialize context.MonitorsIndex. fixes #547

### DIFF
--- a/pkg/api/socketio.go
+++ b/pkg/api/socketio.go
@@ -106,7 +106,11 @@ func (c *ContextCache) loadMonitors() {
 		c.monitorsIndex = newIndex
 	}
 	for _, ctx := range c.Contexts {
-		ctx.MonitorsIndex = newCollectorIndex[ctx.Collector.Id]
+		cIdx, ok := newCollectorIndex[ctx.Collector.Id]
+		if !ok {
+			cIdx = make(map[int64]*m.MonitorDTO)
+		}
+		ctx.MonitorsIndex = cIdx
 	}
 }
 


### PR DESCRIPTION
When a collector had now monitors assigned, context.MonitorsIndex
was being initialized as a nil map. when a new monitor was added
to this collector, trying to add the monitor to the index resulted
in a panic.