### PR TITLE
set metricdata id for alerting metrics

### DIFF
--- a/pkg/alerting/schedule.go
+++ b/pkg/alerting/schedule.go
@@ -63,6 +63,7 @@ func (job Job) StoreResult(res m.CheckEvalResult) {
 				fmt.Sprintf("monitor_id:%d", job.MonitorId),
 			},
 		}
+		metrics[pos].SetId()
 	}
 	if int(res) >= 0 {
 		metrics[int(res)].Value = 1.0


### PR DESCRIPTION
i'm happy that metrictank is now very assertive about missing metric Id in received data.
it helped me find this case.
@woodsaj lookie good?